### PR TITLE
Feat/fix-bot-handler

### DIFF
--- a/src/apps/telegram/bot.py
+++ b/src/apps/telegram/bot.py
@@ -111,7 +111,7 @@ class Bot:
         payload = {
             "chat_id": chat_id,
             "text": text,
-            "parse_mode": cls.parse_mode,
+            # "parse_mode": cls.parse_mode,
         }
         if reply_markup:
             payload["reply_markup"] = reply_markup
@@ -128,7 +128,7 @@ class Bot:
             "chat_id": chat_id,
             "message_id": message_id,
             "text": text,
-            "parse_mode": cls.parse_mode,
+            # "parse_mode": cls.parse_mode,
         }
         if reply_markup:
             # payload["reply_markup"] = {"inline_keyboard": keyboard}

--- a/src/apps/telegram/bot.py
+++ b/src/apps/telegram/bot.py
@@ -1,7 +1,6 @@
 """Telegram bot module."""
 
 import enum
-import logging
 from datetime import datetime
 
 import requests
@@ -24,14 +23,11 @@ class Commands(enum.Enum):
 class Bot:
     """Telegram bot."""
 
-    parse_mode = "MarkdownV2"
-
     @classmethod
     def post(cls, endpoint, payload, timeout=5):
         """Post the payload to the given endpoint."""
         url = cls.construct_endpoint(endpoint)
         response = requests.post(url, json=payload, timeout=timeout)
-        logging.info(f"Telegram: POST {url} {payload} -> {response.status_code} {response.json()}")
         return response
 
     @classmethod
@@ -108,11 +104,7 @@ class Bot:
         References:
         https://core.telegram.org/bots/api#sendmessage
         """
-        payload = {
-            "chat_id": chat_id,
-            "text": text,
-            # "parse_mode": cls.parse_mode,
-        }
+        payload = {"chat_id": chat_id, "text": text}
         if reply_markup:
             payload["reply_markup"] = reply_markup
         cls.post("sendMessage", payload=payload)
@@ -124,14 +116,8 @@ class Bot:
         References:
         https://core.telegram.org/bots/api#editmessagetext
         """
-        payload = {
-            "chat_id": chat_id,
-            "message_id": message_id,
-            "text": text,
-            # "parse_mode": cls.parse_mode,
-        }
+        payload = {"chat_id": chat_id, "message_id": message_id, "text": text}
         if reply_markup:
-            # payload["reply_markup"] = {"inline_keyboard": keyboard}
             payload["reply_markup"] = reply_markup
         cls.post("editMessageText", payload=payload)
 

--- a/src/apps/telegram/bot.py
+++ b/src/apps/telegram/bot.py
@@ -1,6 +1,7 @@
 """Telegram bot module."""
 
 import enum
+import logging
 from datetime import datetime
 
 import requests
@@ -29,7 +30,9 @@ class Bot:
     def post(cls, endpoint, payload, timeout=5):
         """Post the payload to the given endpoint."""
         url = cls.construct_endpoint(endpoint)
-        return requests.post(url, json=payload, timeout=timeout)
+        response = requests.post(url, json=payload, timeout=timeout)
+        logging.info(f"Telegram: POST {url} {payload} -> {response.status_code} {response.json()}")
+        return response
 
     @classmethod
     def handle(cls, update: dict):

--- a/src/apps/telegram/tests.py
+++ b/src/apps/telegram/tests.py
@@ -79,7 +79,7 @@ def _construct_expected_payload(idx: int, fixtures: list[dict], bot_post: MagicM
         message = raw_message["callback_query"]["message"]
     else:
         message = raw_message["message"]
-    payload = {"chat_id": message["chat"]["id"], "text": message["text"], "parse_mode": Bot.parse_mode}
+    payload = {"chat_id": message["chat"]["id"], "text": message["text"]}
     if "reply_markup" in message:
         payload["reply_markup"] = message["reply_markup"]
     if bot_post.call_args[0][0] == "editMessageText":

--- a/src/ida/settings.py
+++ b/src/ida/settings.py
@@ -177,8 +177,8 @@ LOGGING = {
             "class": "logging.FileHandler",
             "filename": environ.from_env(
                 "DJANGO_LOG_FILENAME",
-                default=utils.existing_path(ROOT_DIR / "logs" / "ida.log"),
-                astype=utils.existing_path,
+                default=utils.existing_str_path(ROOT_DIR / "logs" / "ida.log"),
+                astype=utils.existing_str_path,
             ),
         },
         "console": {

--- a/src/ida/settings.py
+++ b/src/ida/settings.py
@@ -175,10 +175,8 @@ LOGGING = {
         "file": {
             "level": environ.from_env("DJANGO_FILE_LOG_LEVEL", default="INFO"),
             "class": "logging.FileHandler",
-            "filename": environ.from_env(
-                "DJANGO_LOG_FILENAME",
-                default=utils.existing_str_path(ROOT_DIR / "logs" / "ida.log"),
-                astype=utils.existing_str_path,
+            "filename": utils.existing_path(
+                environ.from_env("DJANGO_LOG_FILENAME", default=ROOT_DIR / "logs" / "ida.log")
             ),
         },
         "console": {

--- a/src/ida/utils.py
+++ b/src/ida/utils.py
@@ -32,3 +32,9 @@ def existing_path(value: str | Path) -> Path:
     except Exception as e:
         print(f"[WARNING] Could not create log file {path}: {e}")
     return path
+
+
+def existing_str_path(value: str | Path) -> str:
+    """Convert the path to a string."""
+    path = existing_path(value)
+    return str(path)

--- a/src/ida/utils.py
+++ b/src/ida/utils.py
@@ -32,9 +32,3 @@ def existing_path(value: str | Path) -> Path:
     except Exception as e:
         print(f"[WARNING] Could not create log file {path}: {e}")
     return path
-
-
-def existing_str_path(value: str | Path) -> str:
-    """Convert the path to a string."""
-    path = existing_path(value)
-    return str(path)


### PR DESCRIPTION
This PR makes day payloads work. The issue was that we used dashes in the payload and used parse_mode MarkdownV2. This means characters like - should be escaped. No actual need for the parse_mode, so removing it fixed the issue.

Our default logging value was passed to the existing_path function, causing the app to always create the default as well. This was wrong and is corrected.