### PR TITLE
ci: always run code-validation and docker-build-validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/ci.yml"
-      - "requirements/**"
-      - ".cruft.json"
-      - ".gitignore"
-      - "pyproject.toml"
-      - "**/*.py"
 
 jobs:
   validate-code:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,14 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/docker.yml"
-      - "docker/**"
-      - "requirements/**"
-      - ".gitignore"
-      - "compose*.yml"
-      - "Dockerfile"
-      - "pyproject.toml"
 
 jobs:
   validate-docker-build:


### PR DESCRIPTION
Since both code-validation and docker-build-validation are required checks, we want them to run always.

Considered adding a check that "checks if any required files are changed", but this added unneeded complexity or dependencies. For now, let's just always run everything