### PR TITLE
telegram: add should_run method and force option

### DIFF
--- a/src/apps/telegram/management/commands/startcompletetimesheet.py
+++ b/src/apps/telegram/management/commands/startcompletetimesheet.py
@@ -1,5 +1,7 @@
 """Django command to start the CompleteTimesheet command for active users with a chat_id."""
 
+from django.utils import timezone
+
 from apps.telegram.management.commands.base import TelegramCommand
 
 
@@ -8,3 +10,9 @@ class Command(TelegramCommand):
 
     help = "Start the CompleteTimesheet command to let users complete their timesheets."
     command_text = "/completetimesheet"
+
+    def should_run(self):
+        """Only run the command if it's the last day of the month."""
+        today = timezone.now().date()
+        tomorrow = today + timezone.timedelta(days=1)
+        return tomorrow.day == 1

--- a/src/apps/telegram/management/commands/startregisterwork.py
+++ b/src/apps/telegram/management/commands/startregisterwork.py
@@ -1,5 +1,7 @@
 """Django command to start a RegisterWork command for active users with a chat_id."""
 
+from django.utils import timezone
+
 from apps.telegram.management.commands.base import TelegramCommand
 
 
@@ -8,3 +10,7 @@ class Command(TelegramCommand):
 
     help = "Start a RegisterWork command to let users register their work hours."
     command_text = "/registerwork"
+
+    def should_run(self):
+        """Only run on weekdays."""
+        return timezone.now().weekday() < 5

--- a/src/apps/telegram/tests.py
+++ b/src/apps/telegram/tests.py
@@ -115,7 +115,8 @@ class TelegramTestCase(TestCase):
         """Test the start register work command."""
         bot_post = patch("apps.telegram.bot.core.Bot.post", MagicMock()).start()
         out = StringIO()
-        call_command("startregisterwork", stdout=out)
+
+        call_command("startregisterwork", stdout=out, force=True)
         self.assertEqual(bot_post.call_count, 1)
         self.assertEqual(bot_post.call_args.args[0], "sendMessage")
         self.assertIn("Started the command for", out.getvalue())
@@ -125,7 +126,7 @@ class TelegramTestCase(TestCase):
         self.timesheet.save()
         bot_post.reset_mock()
         out = StringIO()
-        call_command("startregisterwork", stdout=out)
+        call_command("startregisterwork", stdout=out, force=True)
         self.assertTrue(bot_post.called)
         self.assertIn("No missing days", bot_post.call_args[1]["payload"]["text"])
 


### PR DESCRIPTION
These things are added to the management commands of telegram so that cronjobs can run daily, but nothing is done if they shouldn't run.

The force option makes it possible to run the management command anyway in case this should ever be needed.